### PR TITLE
Add SQL initialization script for druginfo table

### DIFF
--- a/init.sql
+++ b/init.sql
@@ -1,0 +1,11 @@
+DROP TABLE IF EXISTS druginfo;
+CREATE TABLE druginfo (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    manu_lotnum TEXT,
+    manu_date TEXT,
+    expy_end TEXT,
+    kcsb INTEGER DEFAULT 0,
+    msg TEXT,
+    create_time DATETIME DEFAULT CURRENT_TIMESTAMP
+);


### PR DESCRIPTION
## Summary
- add `init.sql` to create the `druginfo` table for SQLite

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687f3dcec030832abc0555925218b09b