### PR TITLE
Update WSS port and add admin check

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -16,6 +16,7 @@ using System.Threading;
 using MiniJSON;
 using System.ServiceProcess;
 using System.Reflection;
+using System.Security.Principal;
 
 namespace DrugInfoWebSocketServer
 {
@@ -972,7 +973,7 @@ namespace DrugInfoWebSocketServer
                 return;
             }
 
-            int serverPort = 8443;
+            int serverPort = 26663;
             string exeDir = AppDomain.CurrentDomain.BaseDirectory;
             string dbPath = Path.Combine(exeDir, "druginfo.db");
             Program.EnsureDatabase(dbPath);
@@ -1036,6 +1037,19 @@ namespace DrugInfoWebSocketServer
     // 程序入口
     class Program
     {
+        private static bool IsAdministrator()
+        {
+            try
+            {
+                WindowsIdentity identity = WindowsIdentity.GetCurrent();
+                WindowsPrincipal principal = new WindowsPrincipal(identity);
+                return principal.IsInRole(WindowsBuiltInRole.Administrator);
+            }
+            catch
+            {
+                return false;
+            }
+        }
         static void Main(string[] args)
         {
             if (args.Length > 0)
@@ -1051,6 +1065,12 @@ namespace DrugInfoWebSocketServer
                     ServiceHelper.Uninstall();
                     return;
                 }
+            }
+
+            if (Environment.UserInteractive && !IsAdministrator())
+            {
+                Console.WriteLine("请以管理员身份运行本程序。");
+                return;
             }
 
             if (!Environment.UserInteractive)
@@ -1113,7 +1133,7 @@ namespace DrugInfoWebSocketServer
                 return;
             }
 
-            int serverPort = 8443; // WSS标准端口
+            int serverPort = 26663; // WSS端口
             string exeDir = AppDomain.CurrentDomain.BaseDirectory;
             string dbPath = Path.Combine(exeDir, "druginfo.db");
             EnsureDatabase(dbPath);

--- a/README.md
+++ b/README.md
@@ -26,14 +26,14 @@ uninstall_service.bat
 DrugInfoWssServer.exe uninstall
 ```
 
-安装后将创建名为 **DrugInfoWssServer** 的服务，启动类型为自动。服务启动后在后台监听 `wss://localhost:8443`。
+安装后将创建名为 **DrugInfoWssServer** 的服务，启动类型为自动。服务启动后在后台监听 `wss://localhost:26663`。
 
 ## 在 CRX 中使用 WSS
 
-CRX 插件可直接通过 `wss://localhost:8443` 与本服务通信，例如：
+CRX 插件可直接通过 `wss://localhost:26663` 与本服务通信，例如：
 
 ```javascript
-const ws = new WebSocket('wss://localhost:8443');
+const ws = new WebSocket('wss://localhost:26663');
  ws.onopen = () => {
     ws.send(JSON.stringify({action: 'query_druginfo', druginfo: {Name: '药品名称'}}));
 };


### PR DESCRIPTION
## Summary
- update the WSS server port to 26663
- document the new port in README
- add an administrator privilege check on startup

## Testing
- `dotnet build DrugInfoWssServer.csproj` *(fails: target Build does not exist)*
- `xbuild /t:Build /p:Configuration=Release DrugInfoWssServer.csproj` *(fails: target 'Build' not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880a81ee328832aa99b6aecfa52176d