### PR TITLE
Remove automatic OpenSSL installer

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -121,37 +121,13 @@ namespace DrugInfoWebSocketServer
             }
         }
 
-        // 检查并在需要时安装 OpenSSL
+        // 检查 OpenSSL 是否可用
         public static bool EnsureOpenSsl()
         {
             if (CheckOpenSsl())
                 return true;
 
-            string exeDir = AppDomain.CurrentDomain.BaseDirectory;
-            string installer = Path.Combine(exeDir, "Win64OpenSSL-3_5_1.exe");
-            if (File.Exists(installer))
-            {
-                try
-                {
-                    Console.WriteLine("OpenSSL 未检测到，尝试自动安装...");
-                    ProcessStartInfo psi = new ProcessStartInfo(installer, "/silent /sp- /suppressmsgboxes /norestart");
-                    psi.UseShellExecute = false;
-                    psi.RedirectStandardOutput = true;
-                    psi.RedirectStandardError = true;
-                    Process p = Process.Start(psi);
-                    p.WaitForExit();
-                }
-                catch (Exception ex)
-                {
-                    Console.WriteLine("自动安装 OpenSSL 失败: " + ex.Message);
-                }
-            }
-            else
-            {
-                Console.WriteLine("未找到 OpenSSL 安装包: " + installer);
-            }
-
-            // 将默认安装路径加入PATH（仅当前进程）
+            // 将默认安装路径加入 PATH（仅当前进程）
             string opensslDir = @"C:\Program Files\OpenSSL-Win64\bin";
             if (File.Exists(Path.Combine(opensslDir, "openssl.exe")))
             {
@@ -160,13 +136,6 @@ namespace DrugInfoWebSocketServer
                 {
                     Environment.SetEnvironmentVariable("PATH", pathVar + ";" + opensslDir);
                 }
-            }
-
-            for (int i = 0; i < 10; i++)
-            {
-                if (CheckOpenSsl())
-                    return true;
-                Thread.Sleep(3000);
             }
 
             return CheckOpenSsl();

--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@
 运行环境：.NET 2.0 + SQLite3。
 
 启动程序会检查 `server.pfx`，如不存在则尝试使用 `openssl` 自动生成自签名证书。
-若系统未检测到 `openssl`，程序会自动执行同目录下的 `Win64OpenSSL-3_5_1.exe` 安装包，
-并把默认安装路径加入 `PATH` 环境变量，直到能够调用 `openssl` 为止。
+请确保系统已安装 `openssl`，并将其可执行文件所在目录加入 `PATH` 环境变量。
 
 ## 安装为 Windows 服务
 


### PR DESCRIPTION
## Summary
- drop OpenSSL auto installer code and just check the PATH
- update the README to say OpenSSL must be pre-installed

## Testing
- `dotnet build DrugInfoWssServer.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880b5fda8f8832a9c1f57420e5d6ab4