### PR TITLE
Fix JSON alias handling for .NET 2.0

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -926,7 +926,8 @@ namespace DrugInfoWebSocketServer
                     }
                 }
 
-                instanceMutex = new Mutex(true, "DrugInfoWsServerMutex", out _);
+                bool createdNew;
+                instanceMutex = new Mutex(true, "DrugInfoWsServerMutex", out createdNew);
                 return true;
             }
             catch

--- a/SimpleJsonSerializer.cs
+++ b/SimpleJsonSerializer.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
-using System.Linq;
 
 namespace DrugInfoWebSocketServer
 {
@@ -33,19 +32,34 @@ namespace DrugInfoWebSocketServer
                     if (!prop.CanWrite) continue;
 
                     object val = null;
-                    string matchedKey = dict.Keys.FirstOrDefault(k => string.Equals(k, prop.Name, StringComparison.OrdinalIgnoreCase));
+                    string matchedKey = null;
+                    foreach (string k in dict.Keys)
+                    {
+                        if (string.Equals(k, prop.Name, StringComparison.OrdinalIgnoreCase))
+                        {
+                            matchedKey = k;
+                            break;
+                        }
+                    }
                     if (matchedKey != null)
                     {
                         val = dict[matchedKey];
                     }
                     else
                     {
-                        JsonAliasAttribute aliasAttr = prop.GetCustomAttribute<JsonAliasAttribute>();
+                        JsonAliasAttribute aliasAttr = (JsonAliasAttribute)Attribute.GetCustomAttribute(prop, typeof(JsonAliasAttribute));
                         if (aliasAttr != null)
                         {
                             foreach (string alias in aliasAttr.Aliases)
                             {
-                                matchedKey = dict.Keys.FirstOrDefault(k => string.Equals(k, alias, StringComparison.OrdinalIgnoreCase));
+                                foreach (string k in dict.Keys)
+                                {
+                                    if (string.Equals(k, alias, StringComparison.OrdinalIgnoreCase))
+                                    {
+                                        matchedKey = k;
+                                        break;
+                                    }
+                                }
                                 if (matchedKey != null)
                                 {
                                     val = dict[matchedKey];
@@ -153,7 +167,7 @@ namespace DrugInfoWebSocketServer
                 object val = prop.GetValue(obj, null);
                 val = PrepareForSerialize(val);
                 string key = prop.Name;
-                JsonAliasAttribute aliasAttr = prop.GetCustomAttribute<JsonAliasAttribute>();
+                JsonAliasAttribute aliasAttr = (JsonAliasAttribute)Attribute.GetCustomAttribute(prop, typeof(JsonAliasAttribute));
                 if (aliasAttr != null && aliasAttr.Aliases.Length > 0)
                     key = aliasAttr.Aliases[0];
                 result[key] = val;


### PR DESCRIPTION
## Summary
- remove LINQ usage and reflection APIs not present in .NET 2.0
- adjust instance mutex creation for pre-C#7 compatibility

## Testing
- `dotnet` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881a7ce0680832aaa2cd6faa46fe00f